### PR TITLE
KYLIN_HOME will be confused when multiple tomcat instances are deployed on the same node

### DIFF
--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -18,6 +18,11 @@
 #
 
 dir=$(dirname ${0})
+
+# We should set KYLIN_HOME here for multiple tomcat instsances that are on the same node.
+# In addition, we should set a KYLIN_HOME for the global use as normal.
+export KYLIN_HOME=${dir}/../
+
 source ${dir}/check-env.sh
 mkdir -p ${KYLIN_HOME}/logs
 


### PR DESCRIPTION
KYLIN_HOME will be confused when multiple tomcat instances are deployed on the same node, if we just set one KYLIN_HOME for global use on that machine, the multiple tomcats will not find the path directly, thus we set the KYLIN_HOME side kylin.sh, and this KYLIN_HOME's scope is only inside the kylin.sh and its derived scripts. In addition, we can still set a KYLIN_HOME for global use on that machine.
